### PR TITLE
docs(backlog): trim completed items; focus on unfinished work (2025-08-08)

### DIFF
--- a/docs/00_BACKLOG.md
+++ b/docs/00_BACKLOG.md
@@ -1,6 +1,6 @@
 # QuantDB 产品待办清单 (Product Backlog)
 
-**当前Sprint**: Sprint 4 | **版本**: v2.2.8 | **更新**: 2025-08-07
+**当前Sprint**: Sprint 4 | **版本**: v2.2.8 | **更新**: 2025-08-08
 
 ## 🎯 产品现状
 
@@ -21,16 +21,7 @@
 
 ### 🔥 Sprint 4 - Python包国际化 + 社区推广 (本月)
 
-#### ✅ 4.1 国际化收尾工作 (已完成 - 2025-08-06)
-- ✅ **版本显示修复**: 修复PyPI包版本显示不一致问题
-  - ✅ 发布v2.2.6修复版本显示 (qdb.__version__ 显示正确版本)
-  - ✅ 确保setup.py和__init__.py版本号同步
-  - ✅ 验证PyPI包版本显示正确
-- ✅ **用户界面完全英文化**: 完成剩余中文消息翻译
-  - ✅ 翻译日志消息: "已清除所有缓存" → "Cache cleared"
-  - ✅ 翻译配置消息: "日志级别已设置为" → "Log level set to"
-  - ✅ 翻译状态消息: "运行中" → "Running"
-  - ✅ 验证所有用户可见文本为英文
+
 
 #### 4.2 社区推广和营销
 - [ ] **Python社区推广**: 在Python开发者社区分享QuantDB
@@ -51,42 +42,11 @@
 
 #### 4.3 用户反馈和产品优化
 - [ ] **用户反馈收集**: 建立用户反馈渠道
-  - [ ] 创建GitHub Issues模板
+
   - [ ] 建立用户QQ群/微信群
   - [ ] 设置用户满意度调研
   - [ ] 建立功能需求收集机制
-- [ ] **核心API扩展**: 基于用户需求分析的功能增强 🔥
-  - ✅ **实时行情数据API** (🌟已完成 - 2025-08-06)
-    - ✅ 实现 `stock_zh_a_spot` 接口包装
-    - ✅ 添加实时股价缓存策略 (1-5分钟)
-    - ✅ 创建 `/api/v1/realtime/stock/{symbol}` 端点
-    - ✅ 支持批量实时行情查询
-    - ✅ 集成到Python包: `qdb.get_realtime_data()`
-  - ✅ **股票列表API** (🌟已完成 - 2025-08-07)
-    - ✅ 实现 `stock_zh_a_spot_em` 接口包装
-    - ✅ 添加股票列表缓存 (每日更新)
-    - ✅ 创建 `/api/v1/stocks/list` 端点
-    - ✅ 支持按市场筛选 (SHSE/SZSE/HKEX)
-    - ✅ 集成到Python包: `qdb.get_stock_list()`
-  - [x] **指数数据API** ✅ (已完成 2025-08-07)
-    - [x] 实现指数历史数据接口 (`GET /api/v1/index/historical/{symbol}`)
-    - [x] 实现指数实时数据接口 (`GET /api/v1/index/realtime/{symbol}`)
-    - [x] 支持主要指数 (上证/深证/创业板)
-    - [x] Python包集成 (`qdb.get_index_data()`, `qdb.get_index_realtime()`, `qdb.get_index_list()`)
-    - [x] 智能缓存策略 (历史数据永久缓存，实时数据1-5分钟缓存)
-    - [x] 完整API文档和使用指南 (`docs/INDEX_API_GUIDE.md`)
-  - [x] **基础财务数据API** ✅ (已完成 2025-08-07)
-    - [x] 实现财务摘要数据接口
-      - 季度财务摘要数据 (净利润、营业收入、ROE等)
-      - API端点: `GET /api/v1/financial/{symbol}/summary`
-      - Python包: `qdb.get_financial_summary(symbol)`
-      - 智能缓存策略 (24小时TTL)
-    - [x] 添加核心财务指标支持
-      - 详细财务分析指标 (98行×86列数据)
-      - API端点: `GET /api/v1/financial/{symbol}/indicators`
-      - Python包: `qdb.get_financial_indicators(symbol)`
-      - 批量查询: `POST /api/v1/financial/batch`
-      - 周级缓存策略 (7天TTL)
+
 
 ### 📈 Sprint 5 - API服务商业化 (下月)
 
@@ -117,10 +77,7 @@
 ### 🔧 长期Backlog - 按优先级排序
 
 #### 高优先级 (本月)
-- ✅ **国际化收尾**: 修复版本显示和完成用户界面英文化 (已完成)
-- ✅ **核心API扩展**: 实时行情 + 股票列表 (GTM关键功能)
-  - ✅ 实时行情数据API (已完成)
-  - ✅ 股票列表API (已完成 - 2025-08-07)
+
 - [ ] **开源社区建设**: 完善GitHub项目
 - [ ] **用户反馈收集**: 建立反馈渠道和需求收集机制
 
@@ -133,52 +90,7 @@
 - [ ] **多平台支持**: 扩展兼容性
 - [ ] **云平台优化**: Streamlit功能完善
 
-## 🎯 Sprint状态
 
-**当前Sprint**: Sprint 4 - 社区推广和用户获取  
-**Sprint目标**: 获得首批用户，建立反馈渠道  
-**Sprint周期**: 2025-08-05 至 2025-08-19 (2周)
-
-### 🎯 Sprint 4 - Phase 1&2 完成总结 (Sprint Review)
-
-#### ✅ 已完成的用户故事 (Completed User Stories)
-**作为PyPI用户，我希望看到专业的英文界面和正确的版本显示，以便更好地理解和使用QDB包**
-
-**Phase 1 完成的任务**:
-- ✅ `qdb/__init__.py` - 包主入口完全英文化 (4 story points)
-- ✅ `qdb/exceptions.py` - 异常处理完全英文化 (2 story points)
-- ✅ `qdb/simple_client.py` - 简化客户端英文化 (3 story points)
-- ✅ `qdb/client.py` - 主客户端英文化 (3 story points)
-- ✅ 功能完整性测试验证 (2 story points)
-
-**Phase 2 完成的任务 (4.1国际化收尾)**:
-- ✅ 版本显示修复: qdb.__version__ 2.2.4→2.2.6 (2 story points)
-- ✅ 用户消息英文化: 所有剩余中文消息翻译 (3 story points)
-- ✅ 质量验证: 功能完整性和英文化验证 (1 story point)
-
-**Phase 3 完成的任务 (4.3实时行情数据API)**:
-- ✅ AKShare stock_zh_a_spot接口包装 (3 story points)
-- ✅ 实时数据缓存策略实现 (4 story points)
-- ✅ API端点开发: /api/v1/realtime/stock/{symbol} (3 story points)
-- ✅ 批量查询API: /api/v1/batch/realtime (2 story points)
-- ✅ Python包集成: qdb.get_realtime_data() (2 story points)
-- ✅ 综合测试和质量验证 (2 story points)
-
-**Sprint 成果**:
-- 📦 **4个核心文件**完成国际化
-- 🔤 **200+行代码**英文化
-- ⚡ **实时数据API**完整实现
-- 🗄️ **SQLite缓存策略**智能化
-- ✅ **100%功能保持**完整性
-- 🌍 **PyPI就绪**面向国际用户
-- 🎯 **100%国际化**达成里程碑
-
-#### 📈 Sprint 指标 (Sprint Metrics)
-- **计划Story Points**: 36 (Phase 1: 14 + Phase 2: 6 + Phase 3: 16)
-- **完成Story Points**: 36
-- **Sprint目标达成率**: 100%
-- **缺陷数**: 0
-- **技术债务**: 无新增
 
 ### 📊 定义完成 (Definition of Done)
 - [ ] 至少在3个社区平台发布介绍
@@ -205,35 +117,6 @@
 - 每个模块完成后运行: `python -m pytest tests/`
 - 最终验证: 完整的包安装和功能测试
 
----
 
-### 📊 Sprint 4 - Phase 4 完成总结 (2025-08-07)
 
-#### ✅ 股票列表API完成 (Phase 4)
-**作为量化研究者，我希望获取完整的股票列表并按市场筛选，以便进行全市场分析**
-
-**Phase 4 完成的任务**:
-- ✅ AKShare `stock_zh_a_spot_em` 接口包装 (3 story points)
-- ✅ 股票列表缓存模型和服务 (4 story points)
-- ✅ API端点开发: `/api/v1/stocks/list` (3 story points)
-- ✅ 市场筛选功能: SHSE/SZSE/HKEX (2 story points)
-- ✅ Python包集成: `qdb.get_stock_list()` (2 story points)
-- ✅ 质量保证和测试验证 (2 story points)
-
-**实现成果**:
-- 📊 **5,736只股票**完整列表获取
-- 🏢 **市场分类**：SHSE(2,417) + SZSE(3,319) + HKEX支持
-- ⚡ **智能缓存**：首次2分钟，后续毫秒级响应
-- 🔧 **完整集成**：API + Python包双重支持
-- ✅ **质量保证**：100%功能测试通过
-
-#### 📈 Sprint 4 总体指标
-- **计划Story Points**: 52 (Phase 1-4: 14 + 6 + 16 + 16)
-- **完成Story Points**: 52
-- **Sprint目标达成率**: 100%
-- **核心功能完成**: 实时行情 + 股票列表 ✅
-- **技术债务**: 无新增
-
----
-
-*最后更新: 2025-08-07 | Sprint 4 Phase 1&2&3&4: ✅ COMPLETED | 项目状态: 100%国际化+实时API+股票列表API完成，PyPI v2.2.6就绪*
+*最后更新: 2025-08-08 | 当前Sprint: 推广与用户获取进行中 | 状态: Backlog已精简，仅保留未完成项；重要更新见CHANGELOG v2.2.8*


### PR DESCRIPTION
This PR cleans up the Product Backlog for agility:

- Remove completed sections (4.1 i18n wrap-up, 4.3 core API expansions) and sprint summaries/metrics
- Remove completed high-priority entries
- Remove the already-done GitHub issue templates task (templates exist under .github/ISSUE_TEMPLATE)
- Update timestamps and final note to reference CHANGELOG v2.2.8 for important updates

Rationale:
- Keep the backlog lean and value-focused, only retaining unfinished, actionable items
- Align with Scrum/Kanban hygiene and KISS principle

No code changes, docs only.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author