### PR TITLE
docs(pypi): update README_PYPI for v2.2.8 and export index APIs

### DIFF
--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -28,7 +28,7 @@ df = qdb.get_stock_data("000001", start_date="20240101", end_date="20240131")  #
 ## ✨ Key Features
 
 - **🚀 90%+ Performance Boost**: Local SQLite cache avoids repeated network requests
-- **🧠 Smart Incremental Updates**: Only fetch missing data, maximize cache efficiency  
+- **🧠 Smart Incremental Updates**: Only fetch missing data, maximize cache efficiency
 - **⚡ Millisecond Response**: Cache hit response time < 10ms
 - **📅 Trading Calendar Integration**: Smart data acquisition based on real trading calendar
 - **🔧 Zero Configuration**: Automatically initialize local cache database
@@ -83,6 +83,11 @@ all_stocks = qdb.get_stock_list()  # All markets
 shse_stocks = qdb.get_stock_list(market="SHSE")  # Shanghai Stock Exchange
 szse_stocks = qdb.get_stock_list(market="SZSE")  # Shenzhen Stock Exchange
 
+# Index data (now available via top-level qdb)
+index_hist = qdb.get_index_data("000001", start_date="20240101", end_date="20240201")
+index_rt = qdb.get_index_realtime("000001")
+index_list = qdb.get_index_list()  # Or filter by category
+
 # Financial data and indicators
 financial_summary = qdb.get_financial_summary("000001")  # Key metrics
 financial_indicators = qdb.get_financial_indicators("000001")  # Detailed ratios
@@ -107,6 +112,12 @@ qdb.set_cache_dir("./my_custom_cache")
 qdb.set_log_level("INFO")  # DEBUG, INFO, WARNING, ERROR
 ```
 
+## 🔍 Feature details
+
+- Real-time data: Trading-hours TTL vs. off-hours TTL to minimize latency and API calls; automatic cache hit detection and graceful fallback
+- Stock list: Market filter via market="SHSE"/"SZSE"/"HKEX"; daily caching with force_refresh toggle
+- Financial metrics: Summary and indicators endpoints designed for quick lookups and lightweight analysis
+
 ## 🎯 Use Cases
 
 - **Quantitative Research**: Frequent backtesting with cached historical data
@@ -115,12 +126,12 @@ qdb.set_log_level("INFO")  # DEBUG, INFO, WARNING, ERROR
 - **Portfolio Management**: Multi-asset data retrieval and analysis
 - **Academic Research**: Reliable data source for financial studies
 
-## 🎉 New in v2.2.7
+## 🎉 What's new in v2.2.8
 
-- **✅ Real-time Stock Quotes**: Live market data with smart caching
-- **✅ Stock List API**: Complete market coverage and filtering
-- **✅ Index Data**: Major indices support (SSE, SZSE, etc.)
-- **✅ Financial Metrics**: Key financial indicators and ratios
+- ✅ Easier API usage: get_stock_data() now supports positional, keyword, and mixed arguments
+- ✅ Documentation and examples updated: Improved UX and clarity
+- ✅ Quality assured: 149/149 tests passing (100%)
+- ✅ Version alignment: Unified version across files; PyPI-ready packaging
 
 ## 📚 Documentation & Support
 
@@ -134,7 +145,7 @@ qdb.set_log_level("INFO")  # DEBUG, INFO, WARNING, ERROR
 QuantDB provides multiple deployment options:
 
 1. **📦 Python Package** (This Package): Local caching for individual developers
-2. **🚀 API Service**: Enterprise-grade REST API with advanced features  
+2. **🚀 API Service**: Enterprise-grade REST API with advanced features
 3. **☁️ Cloud Platform**: Web interface with visualization and monitoring
 
 ## 🤝 Contributing

--- a/qdb/__init__.py
+++ b/qdb/__init__.py
@@ -35,6 +35,11 @@ from .client import (
     # Stock list functionality
     get_stock_list,
 
+    # Index data functionality
+    get_index_data,
+    get_index_realtime,
+    get_index_list,
+
     # Financial data functionality
     get_financial_summary,
     get_financial_indicators,
@@ -78,6 +83,11 @@ __all__ = [
 
     # Stock list functionality
     "get_stock_list",
+
+    # Index data functionality
+    "get_index_data",
+    "get_index_realtime",
+    "get_index_list",
 
     # Financial data functionality
     "get_financial_summary",


### PR DESCRIPTION
This PR updates the PyPI README and exports index APIs at the top-level:

- Replace 'New in v2.2.7' with 'What’s new in v2.2.8'
- Add a concise 'Feature details' section (realtime TTLs, market filters, financial metrics)
- Add index API examples in the Advanced Features section
- Export get_index_data/get_index_realtime/get_index_list in qdb.__init__

Rationale:
- Align PyPI page with docs/01_CHANGELOG.md (v2.2.8)
- Avoid user confusion and highlight new UX improvements
- Enable index APIs from top-level import for easier discovery

No dependency changes. Local import check requires pandas to be installed; function presence validated via source.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author