### PR TITLE
chore(deps): relax tenacity constraint for compatibility with google-genai & llama-index

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -10,7 +10,7 @@ httpx>=0.28.0
 sqlalchemy>=2.0.0
 pandas>=2.3.0
 akshare>=1.17.0
-tenacity>=9.1.0
+tenacity>=8.2.3,<9.0.0,!=8.4.0
 
 # Development and testing
 pytest>=6.2.0

--- a/cloud/streamlit_cloud/requirements.txt
+++ b/cloud/streamlit_cloud/requirements.txt
@@ -33,7 +33,7 @@ uvicorn>=0.15.0
 httpx>=0.18.0
 
 # 重试机制（core服务需要）
-tenacity>=9.1.0
+tenacity>=8.2.3,<9.0.0,!=8.4.0
 
 # 认证相关（core模块可能需要）
 python-jose>=3.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "numpy>=1.20.0",
     "akshare>=1.0.0",
     "sqlalchemy>=1.4.0",
-    "tenacity>=9.1.0",
+    "tenacity>=8.2.3,<9.0.0,!=8.4.0",
     "python-dateutil>=2.8.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -22,10 +22,10 @@ def read_requirements(filename):
 # Basic dependencies
 install_requires = [
     "pandas>=1.3.0",
-    "numpy>=1.20.0", 
+    "numpy>=1.20.0",
     "akshare>=1.0.0",
     "sqlalchemy>=1.4.0",
-    "tenacity>=9.1.0",
+    "tenacity>=8.2.3,<9.0.0,!=8.4.0",
     "python-dateutil>=2.8.0",
 ]
 


### PR DESCRIPTION
This PR relaxes the `tenacity` dependency constraint to resolve common environment conflicts with `google-genai` and `llama-index` while preserving QuantDB functionality.

Changes:
- pyproject.toml: `tenacity>=8.2.3,<9.0.0,!=8.4.0`
- setup.py: `tenacity>=8.2.3,<9.0.0,!=8.4.0`
- api/requirements.txt: `tenacity>=8.2.3,<9.0.0,!=8.4.0`
- cloud/streamlit_cloud/requirements.txt: `tenacity>=8.2.3,<9.0.0,!=8.4.0`

Rationale:
- Users commonly install QuantDB alongside `google-genai` and `llama-index`, which require `tenacity<9.0.0`. QuantDB uses only basic tenacity features (`retry`, `stop_after_attempt`, `wait_exponential`, `reraise`) available since 8.x.

Impact:
- No functional changes to QuantDB.
- Improves compatibility with popular AI libraries.

Testing:
- Local static review; QuantDB code paths only rely on basic tenacity APIs.

Follow-up:
- Consider a patch release (e.g., 2.2.9) after CI passes.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author